### PR TITLE
printf, sprintf function now behaves almost like original implementation.

### DIFF
--- a/exts/jphp-compress-ext/src/main/tests/php/runtime/util/PrintFTest.java
+++ b/exts/jphp-compress-ext/src/main/tests/php/runtime/util/PrintFTest.java
@@ -1,0 +1,84 @@
+package php.runtime.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.develnext.jphp.core.compiler.jvm.JvmCompilerCase;
+import org.develnext.jphp.zend.ext.standard.StandardExtension;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.MethodSorters;
+
+import php.runtime.Memory;
+import php.runtime.env.CompileScope;
+import php.runtime.memory.LongMemory;
+import php.runtime.memory.StringMemory;
+
+@RunWith(JUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PrintFTest extends JvmCompilerCase {
+    static final Memory INT_MAX = LongMemory.valueOf(Integer.MAX_VALUE);
+    static final Memory INT_MIN = LongMemory.valueOf(Integer.MIN_VALUE);
+
+    static final Memory LONG_MAX = LongMemory.valueOf(Long.MAX_VALUE);
+    static final Memory LONG_MIN = LongMemory.valueOf(Long.MIN_VALUE);
+
+    @Override
+    protected CompileScope newScope() {
+        CompileScope scope = super.newScope();
+        scope.registerExtension(new StandardExtension());
+        return scope;
+    }
+
+    @Test
+    public void unsigned() {
+        assertEquals("2147483647", printf("%u", INT_MAX));
+        assertEquals("18446744071562067968", printf("%u", INT_MIN));
+
+        assertEquals("9223372036854775807", printf("%u", LONG_MAX));
+        assertEquals("9223372036854775808", printf("%u", LONG_MIN));
+    }
+
+    @Test
+    public void ldModifier() {
+        Memory arg = LongMemory.valueOf(32);
+
+        Map<Character, String> map = new HashMap<>();
+        map.put('d', "32");
+        map.put('u', "32");
+        map.put('x', "20");
+        map.put('X', "20");
+        map.put('b', "100000");
+        map.put('B', "100000");
+
+        map.forEach((modifier, expected) -> assertEquals(expected, printf("%l" + modifier, arg)));
+    }
+
+    @Test
+    public void skippingUnknownModifiers() {
+        assertEquals("u", printf("%hu", INT_MAX));
+        assertEquals("", printf("%h", INT_MAX));
+
+        assertEquals("", printf("%L", INT_MAX));
+        assertEquals("u", printf("%Lu", INT_MAX));
+        assertEquals("", printf("%q", INT_MAX));
+    }
+
+    @Test
+    public void lModifierWithPadding() {
+        // %ld with left padding
+        assertEquals("00001", printf("%05ld", Memory.CONST_INT_1));
+        assertEquals("1    ", printf("%-5ld", Memory.CONST_INT_1));
+        assertEquals("    1", printf("%5ld", Memory.CONST_INT_1));
+    }
+
+    private String printf(String format, Memory... args) {
+        PrintF printF = new PrintF(environment.getLocale(), format, args);
+        String result = printF.toString();
+        return result;
+    }
+}

--- a/exts/jphp-zend-ext/src/main/java/org/develnext/jphp/zend/ext/standard/StringFunctions.java
+++ b/exts/jphp-zend-ext/src/main/java/org/develnext/jphp/zend/ext/standard/StringFunctions.java
@@ -177,8 +177,16 @@ public class StringFunctions extends FunctionsContainer {
     }
 
 
-    public static Memory sprintf(Environment env, TraceInfo trace, String format, Memory... args) {
-        PrintF printF = new PrintF(env.getLocale(), format, args);
+    public static Memory sprintf(Environment env, TraceInfo trace, Memory formatMemory, Memory... args) {
+        if (formatMemory.isArray()) {
+            env.notice(trace, "Array to string conversion");
+        }
+
+        if (args == null) {
+            args = Memory.CONST_EMPTY_ARRAY;
+        }
+
+        PrintF printF = new PrintF(env.getLocale(), formatMemory.toString(), args);
         String result = printF.toString();
         if (result == null) {
             env.warning(trace, "Too few arguments");
@@ -187,14 +195,14 @@ public class StringFunctions extends FunctionsContainer {
             return new StringMemory(result);
     }
 
-    public static Memory vsprintf(Environment env, TraceInfo trace, String format, Memory array) {
+    public static Memory vsprintf(Environment env, TraceInfo trace, Memory format, Memory array) {
         if (array.isArray()) {
             return sprintf(env, trace, format, array.toValue(ArrayMemory.class).values());
         } else
             return sprintf(env, trace, format, array);
     }
 
-    public static int printf(Environment env, TraceInfo trace, String format, Memory... args) {
+    public static int printf(Environment env, TraceInfo trace, Memory format, Memory... args) {
         Memory str = sprintf(env, trace, format, args);
         if (str.isNull())
             return 0;
@@ -205,7 +213,7 @@ public class StringFunctions extends FunctionsContainer {
         }
     }
 
-    public static int vprintf(Environment env, TraceInfo trace, String format, Memory array) {
+    public static int vprintf(Environment env, TraceInfo trace, Memory format, Memory array) {
         if (array.isArray()) {
             return printf(env, trace, format, array.toValue(ArrayMemory.class).values());
         } else

--- a/jphp-runtime/src/php/runtime/Memory.java
+++ b/jphp-runtime/src/php/runtime/Memory.java
@@ -119,6 +119,7 @@ abstract public class Memory implements Comparable<Memory> {
     public static final Memory CONST_DOUBLE_NAN = new DoubleMemory(Double.NaN);
 
     public static final Memory CONST_EMPTY_STRING = new StringMemory("");
+    public static final Memory[] CONST_EMPTY_ARRAY = new Memory[0];
 
     public boolean isNull(){
         return type == Type.NULL;

--- a/jphp-runtime/src/php/runtime/env/Environment.java
+++ b/jphp-runtime/src/php/runtime/env/Environment.java
@@ -1071,6 +1071,10 @@ public class Environment {
         triggerMessage(new NoticeMessage(peekCall(0), new Messages.Item(message), args));
     }
 
+    public void notice(TraceInfo trace, String message, Object... args) {
+        error(trace, E_NOTICE, message, args);
+    }
+
     public OutputBuffer getDefaultBuffer() {
         return defaultBuffer;
     }


### PR DESCRIPTION
The `printf` and friends almost always return same things, raises messages like original implementation.

Here are changes:
- Prints notice message when format is an array.
- Supports `%ld`, `%lu`, etc formats.
- Skipping unknown modifiers like `%q` or `%w`.

@dim-s Also there is a bunch of `.phpt`s from PHP repository that not included in this PR. I was looking and did not found the original `.phpt`s, but did not found them. I would like to add them also because they expose all inconsistencies. I've even found the syntax error using test files, any many other bug, not directly related to `printf` so it would be nice to include those tests as well.

