### PR TITLE
Игнорирование ошибки, если невозможно удалить файл

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ package.github.yml
 package.hub.yml
 
 *.hprof
+.phpintel/*

--- a/packager/src-php/Tasks.php
+++ b/packager/src-php/Tasks.php
@@ -114,7 +114,7 @@ class Tasks
      * @param bool $ignoreErrs
      * @return bool
      */
-    static function deleteFile(string $path, bool $ignoreErrs = false): bool
+    static function deleteFile(string $path, bool $ignoreErrs = true): bool
     {
         if (fs::exists($path)) {
             Console::log("-> delete file '{0}'", $path);


### PR DESCRIPTION
В dn если удалить бандл, то некоторые файлы невозможно удалить, т.к. они заняты процессом java. При сборке проекта jppm выдаёт ошибку, т.к. не может удалить эти файлы и останавливается процесс сборки. 
Мб не совсем красивое решение, но может не прерывать процесс сборки, а лишь выводить уведомление, т.к. оставшиеся файлы по сути никак не влияют на сборку.
Иначе после каждого удаления бандла придётся перезапускать среду.