### PR TITLE
Isset performed on string offset works correctly.

### DIFF
--- a/jphp-core/tests/php/runtime/memory/StringMemoryTest.java
+++ b/jphp-core/tests/php/runtime/memory/StringMemoryTest.java
@@ -1,5 +1,8 @@
 package php.runtime.memory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static php.runtime.env.TraceInfo.UNKNOWN;
+
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -348,5 +351,30 @@ public class StringMemoryTest {
         Assert.assertTrue(memory.greaterEq("foobar"));
         Assert.assertTrue(memory.greater(new StringMemory("foobar")));
         Assert.assertTrue(memory.greaterEq(new StringMemory("foobar")));
+    }
+
+    @Test
+    public void testIssetOfIndexEmptyString() {
+        StringMemory memory = new StringMemory("");
+
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_1)).isEqualTo(Memory.FALSE);
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_0)).isEqualTo(Memory.FALSE);
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_M1)).isEqualTo(Memory.FALSE);
+    }
+
+    @Test
+    public void testIssetOfIndexNegative() {
+        StringMemory memory = new StringMemory("abc");
+
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_3)).isEqualTo(Memory.FALSE);
+    }
+
+    @Test
+    public void testIssetOfIndexPositive() {
+        StringMemory memory = new StringMemory("abc");
+
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_0)).isEqualTo(Memory.TRUE);
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_1)).isEqualTo(Memory.TRUE);
+        assertThat(memory.issetOfIndex(UNKNOWN, Memory.CONST_INT_2)).isEqualTo(Memory.TRUE);
     }
 }

--- a/jphp-runtime/src/php/runtime/memory/StringMemory.java
+++ b/jphp-runtime/src/php/runtime/memory/StringMemory.java
@@ -66,6 +66,14 @@ public class StringMemory extends Memory {
         return toLong(value, false);
     }
 
+    @Override
+    public Memory issetOfIndex(TraceInfo trace, Memory index) {
+        int idx = index.toInteger();
+        int length = value.length();
+
+        return idx >= length || idx < 0 ? Memory.FALSE : Memory.TRUE;
+    }
+
     public static Memory toLong(String value, boolean bigNumbers){
         int len = value.length();
         if (len == 0)


### PR DESCRIPTION
Problem:

```php
$str = "foo";
var_dump(isset($str[0])); // bool(false) but should be bool(true)
```